### PR TITLE
Downgrade dependencies and remove unwanted changes in #1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-requests==2.26.0
-numpy==1.21.3
-matplotlib==3.4.3
-astropy==4.3.1
-beautifulsoup4==4.10.0
-click==8.0.3

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = canuvit
-version = 0.3.0.dev1
+version = 0.3.0
 author = Prajwel Joseph
 author_email = prajwel.pj@gmail.com
 description = UVIT safety checks
@@ -21,11 +21,11 @@ packages = find:
 python_requires = >=3.6
 install_requires =
     requests>=2
-    numpy>=1.16
+    numpy>=1.13
     matplotlib>=2
-    astropy>=4
-    beautifulsoup4>=4.5
-    click>=8
+    astropy>=2
+    beautifulsoup4>=4.4
+    click>=2
 
 [options.entry_points]
 console_scripts =

--- a/src/canuvit/cli.py
+++ b/src/canuvit/cli.py
@@ -41,7 +41,7 @@ class OnceSameNameOption(click.Option):
 
 
 class CheckREParamType(click.ParamType):
-    def __init__(self, pattern: re.Pattern, name: str, humanpattern: str = None):
+    def __init__(self, pattern, name, humanpattern=None):
         super().__init__()
         self.name = name
         self.pattern = pattern

--- a/src/canuvit/cli.py
+++ b/src/canuvit/cli.py
@@ -73,7 +73,8 @@ DECstr = CheckREParamType(DECre, "DEC", "[-]dd:mm:ss[.ss]")
     "context",
     flag_value="all",
     default=True,
-    help="Check safety for all filters. Default behaviour.",
+    help="Check safety for all filters.",
+    show_default=True,
     cls=OnceSameNameOption,
 )
 @click.option(


### PR DESCRIPTION
So I downgraded the dependencies. These are the oldest versions which I am still able to install and which gives proper results in a blank python 3.6 virtual environment.
```
    requests>=2
    numpy>=1.13
    matplotlib>=2
    astropy>=2
    beautifulsoup4>=4.4
    click>=2
```

From my searching around in stackoverflow, I learned that it is not really the developers job to provide the `requirements.txt` file. So I have removed that as well.

Also some minor corrections to the CLI code. There was no need to put type annotations there.